### PR TITLE
Auto regenerate completions and snippets

### DIFF
--- a/.github/workflows/update-completions.yml
+++ b/.github/workflows/update-completions.yml
@@ -1,0 +1,19 @@
+name: Update Completions
+
+on:
+  schedule:
+    - cron: '0 0 1 1 *' # Run at midnight on January 1st each year
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Run regeneration script 1
+      run: node sublime_completions.js
+
+    - name: Run regeneration script 2
+      run: node license_header_snippets.js


### PR DESCRIPTION
Add GitHub workflow for yearly regeneration of completions and snippets
This commit introduces a GitHub workflow with a scheduled cron job to automatically regenerate completions and snippets once per year. By ensuring that copyright years are up-to-date, users can easily access the latest files by pulling the changes from the repository. This workflow streamlines the process of maintaining and updating completions and snippets for Sublime Text users.